### PR TITLE
feature/dynamic-titles

### DIFF
--- a/views/detail-event.liquid
+++ b/views/detail-event.liquid
@@ -1,4 +1,5 @@
-{% render 'partials/head.liquid' %}
+{% assign pageTitle = eventDetails.title | append: " - Dutch Digital Agencies" %}
+{% render 'partials/head.liquid', pageTitle: pageTitle %}
 <script src="scripts/script.js" defer></script>
 
 <main class="main-home">

--- a/views/events.liquid
+++ b/views/events.liquid
@@ -1,4 +1,5 @@
-{% render 'partials/head.liquid' %}
+{% assign pageTitle = "Events - Dutch Digital Agencies" %}
+{% render 'partials/head.liquid', pageTitle: pageTitle %}
 <script src="scripts/script.js" defer></script>
 
 <main class="main-home">

--- a/views/home.liquid
+++ b/views/home.liquid
@@ -1,4 +1,5 @@
-{% render 'partials/head.liquid' %}
+{% assign pageTitle = "Dutch Digital Agencies" %}
+{% render 'partials/head.liquid', pageTitle: pageTitle %}
 <script src="scripts/script.js" defer></script>
 
 <main class="main-home">

--- a/views/leden.liquid
+++ b/views/leden.liquid
@@ -1,9 +1,9 @@
-{% render 'partials/head.liquid' %}
-<script src="scripts/script.js" defer></script>
 {% assign pageTitle = "Onze leden - Dutch Digital Agencies" %}
+{% render 'partials/head.liquid', pageTitle: pageTitle %}
+<script src="scripts/script.js" defer></script>
 
-<main>
-    {% render 'partials/header.liquid', pageTitle: pageTitle %}
+<main class="main-home">
+    {% render 'partials/header.liquid' %}
 
     <section class="page-title-container">
         <section class="page-title">

--- a/views/lid.liquid
+++ b/views/lid.liquid
@@ -1,8 +1,10 @@
-{% render 'partials/head.liquid' %}
 {% assign pageTitle = lidDetails.title | append: " - Dutch Digital Agencies" %}
-{% render 'partials/header.liquid', pageTitle: pageTitle %}
+{% render 'partials/head.liquid', pageTitle: pageTitle %}
 
-<main class="lid-details-main">
+<main class="lid-details-main main-home">
+
+    {% render 'partials/header.liquid' %}
+
     <section class="page-title">
         <a href="/leden">
         <img src="/img/arrow-left-black.svg" alt="" width="16" height="16">terug naar home
@@ -31,14 +33,14 @@
 
     <section class="contact">
         <h2>contact</h2>
-        <p class="text">{{ lidDetails.title }}</p>
+        <p>{{ lidDetails.title }}</p>
         {% assign addressDetails = lidDetails.address | split: " "  %}
         {% comment %} TODO: get first two of array, get everything after the first 2 {% endcomment %}
-        <p class="text">{{addressDetails[0] }} {{addressDetails[1] }}<br>
+        <p>{{addressDetails[0] }} {{addressDetails[1] }}<br>
         {{ addressDetails[2] }} {{ addressDetails[3] }} {{ addressDetails[4] }} {{ addressDetails[5] }}
         </p>
-        <p class="text"><a href="{{ lidDetails.phone }}">{{ lidDetails.phone }}</p></a>
-        <p class="text"><a href="mailto:{{ lidDetails.email }}">{{ lidDetails.email }}</p></a>
+        <a href="{{ lidDetails.phone }}">{{ lidDetails.phone }}</p></a>
+        <a href="mailto:{{ lidDetails.email }}">{{ lidDetails.email }}</p></a>
     </section>
 </main>
 {% render 'partials/footer.liquid' %}

--- a/views/overons.liquid
+++ b/views/overons.liquid
@@ -1,4 +1,5 @@
-{% render 'partials/head.liquid' %}
+{% assign pageTitle = "Over ons - Dutch Digital Agencies" %}
+{% render 'partials/head.liquid', pageTitle: pageTitle %}
 <script src="scripts/script.js" defer></script>
 
 <main class="main-home">

--- a/views/partials/head.liquid
+++ b/views/partials/head.liquid
@@ -22,7 +22,6 @@
     <link rel="stylesheet" href="/styles/events-page.css">
     <link rel="stylesheet" href="/styles/backtohome-redirect.css">
     <link rel="stylesheet" href="/styles/overons.css">
-    {% assign pageTitle = "Dutch Digital Agencies" %}
     <title>
         {{ pageTitle }}
     </title>

--- a/views/vacatures.liquid
+++ b/views/vacatures.liquid
@@ -1,4 +1,5 @@
-{% render 'partials/head.liquid' %}
+{% assign pageTitle = "Vacatures - Dutch Digital Agencies" %}
+{% render 'partials/head.liquid', pageTitle: pageTitle %}
 <script src="scripts/script.js" defer></script>
 
 {% render 'partials/header.liquid' %}


### PR DESCRIPTION
## What does this change?

Ik heb voor elke pagina een dynamische titel gemaakt met liquid zodat je altijd ziet in je tabblad op welke pagina je bent. @Matthijs217 kun jij dit zelf doen op de publicaties pagina, als voorbeeld kun je kijken naar de bovenste line op een andere pagina.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] [User test]()

## Images
<img width="251" alt="Scherm­afbeelding 2025-05-26 om 10 58 58" src="https://github.com/user-attachments/assets/94c5183c-4a52-4ba3-bf45-886352483a8f" />

<img width="254" alt="Scherm­afbeelding 2025-05-26 om 10 59 08" src="https://github.com/user-attachments/assets/dc7cdf2f-ea4a-4099-9049-fb86f90ab776" />


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

Kijk even in de tabblad van de browser van jullie pagina of het goed word weergegeven.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->